### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# fluent-plugin-sampling-filter, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-sampling-filter
 
 ## Component
 
 ### SamplingFilterOutput
 
-Do sampling from matching messages to analyse and report messages behavior, and emit sampled messages with modified tag.
+This is a [Fluentd](http://fluentd.org) plugin to sample matching messages to analyse and report messages behavior and emit sampled messages with modified tag.
 
 * sampling rate per tags, or for all
 * remove_prefix of tags for input messages, and add_prefix of tags for output(sampled) messages


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
