### PR TITLE
Use router accessor

### DIFF
--- a/fluent-plugin-sampling-filter.gemspec
+++ b/fluent-plugin-sampling-filter.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.12.0", "< 2"]
 end

--- a/lib/fluent/plugin/out_sampling_filter.rb
+++ b/lib/fluent/plugin/out_sampling_filter.rb
@@ -47,7 +47,7 @@ class Fluent::SamplingFilterOutput < Fluent::Output
     end
 
     time_record_pairs.each {|t,r|
-      Fluent::Engine.emit(tag, t, r)
+      router.emit(tag, t, r)
     }
   end
 


### PR DESCRIPTION
In my understanding, fluentd 0.12.0 or later provides `router` accessor and users can access `EventRouter#emit` via `router`, rights?