### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-sampling-filter.gemspec
+++ b/fluent-plugin-sampling-filter.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake"
+  gem.add_runtime_dependency "test-unit", "~> 3.1.0"
   gem.add_runtime_dependency "fluentd", [">= 0.12.0", "< 2"]
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible layer.

I forgot to open PR adding `test-unit` gem dependency.... :cold_sweat: 