### PR TITLE
Add filter sampling plugin and use omit in test

### DIFF
--- a/lib/fluent/plugin/filter_sampling.rb
+++ b/lib/fluent/plugin/filter_sampling.rb
@@ -21,14 +21,13 @@ class Fluent::SamplingFilter < Fluent::Filter
   end
 
   def filter_stream(tag, es)
-    new_es = Fluent::MultiEventStream.new
     t = if @sample_unit == :all
           'all'
         else
           tag
         end
 
-    pairs = []
+    new_es = Fluent::MultiEventStream.new
 
     # Access to @counts SHOULD be protected by mutex, with a heavy penalty.
     # Code below is not thread safe, but @counts (counter for sampling rate) is not

--- a/lib/fluent/plugin/filter_sampling.rb
+++ b/lib/fluent/plugin/filter_sampling.rb
@@ -1,0 +1,63 @@
+class Fluent::SamplingFilter < Fluent::Filter
+  Fluent::Plugin.register_filter('sampling_filter', self)
+
+  config_param :interval, :integer
+  config_param :sample_unit, :string, default: 'tag'
+  config_param :minimum_rate_per_min, :integer, default: nil
+
+  def configure(conf)
+    super
+
+    @sample_unit = case @sample_unit
+                   when 'tag'
+                     :tag
+                   when 'all'
+                     :all
+                   else
+                     raise Fluent::ConfigError, "sample_unit allows only 'tag' or 'all'"
+                   end
+    @counts = {}
+    @resets = {} if @minimum_rate_per_min
+  end
+
+  def filter_stream(tag, es)
+    new_es = Fluent::MultiEventStream.new
+    t = if @sample_unit == :all
+          'all'
+        else
+          tag
+        end
+
+    pairs = []
+
+    # Access to @counts SHOULD be protected by mutex, with a heavy penalty.
+    # Code below is not thread safe, but @counts (counter for sampling rate) is not
+    # so serious value (and probably will not be broken...),
+    # then i let here as it is now.
+    if @minimum_rate_per_min
+      unless @resets[t]
+        @resets[t] = Fluent::Engine.now + (60 - rand(30))
+      end
+      if Fluent::Engine.now > @resets[t]
+        @resets[t] = Fluent::Engine.now + 60
+        @counts[t] = 0
+      end
+      es.each do |time,record|
+        c = (@counts[t] = @counts.fetch(t, 0) + 1)
+        if c < @minimum_rate_per_min or c % @interval == 0
+          new_es.add(time, record.dup)
+        end
+      end
+    else
+      es.each do |time,record|
+        c = (@counts[t] = @counts.fetch(t, 0) + 1)
+        if c % @interval == 0
+          new_es.add(time, record.dup)
+          # reset only just before @counts[t] is to be bignum from fixnum
+          @counts[t] = 0 if c > 0x6fffffff
+        end
+      end
+    end
+    new_es
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
 require 'fluent/plugin/out_sampling_filter'
+require 'fluent/plugin/filter_sampling'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -37,51 +37,51 @@ class SamplingFilterTest < Test::Unit::TestCase
     d1 = create_driver(CONFIG, 'input.hoge1')
     time = Time.parse("2012-01-02 13:14:15").to_i
     d1.run do
-      d1.emit({'field1' => 'record1', 'field2' => 1})
-      d1.emit({'field1' => 'record2', 'field2' => 2})
-      d1.emit({'field1' => 'record3', 'field2' => 3})
-      d1.emit({'field1' => 'record4', 'field2' => 4})
-      d1.emit({'field1' => 'record5', 'field2' => 5})
-      d1.emit({'field1' => 'record6', 'field2' => 6})
-      d1.emit({'field1' => 'record7', 'field2' => 7})
-      d1.emit({'field1' => 'record8', 'field2' => 8})
-      d1.emit({'field1' => 'record9', 'field2' => 9})
-      d1.emit({'field1' => 'record10', 'field2' => 10})
-      d1.emit({'field1' => 'record11', 'field2' => 11})
-      d1.emit({'field1' => 'record12', 'field2' => 12})
+      d1.filter({'field1' => 'record1', 'field2' => 1})
+      d1.filter({'field1' => 'record2', 'field2' => 2})
+      d1.filter({'field1' => 'record3', 'field2' => 3})
+      d1.filter({'field1' => 'record4', 'field2' => 4})
+      d1.filter({'field1' => 'record5', 'field2' => 5})
+      d1.filter({'field1' => 'record6', 'field2' => 6})
+      d1.filter({'field1' => 'record7', 'field2' => 7})
+      d1.filter({'field1' => 'record8', 'field2' => 8})
+      d1.filter({'field1' => 'record9', 'field2' => 9})
+      d1.filter({'field1' => 'record10', 'field2' => 10})
+      d1.filter({'field1' => 'record11', 'field2' => 11})
+      d1.filter({'field1' => 'record12', 'field2' => 12})
     end
-    emits = d1.emits
-    assert_equal 1, emits.length
-    assert_equal 'input.hoge1', emits[0][0] # tag
-    assert_equal 'record10', emits[0][2]['field1']
-    assert_equal 10, emits[0][2]['field2']
+    filtered = d1.filtered_as_array
+    assert_equal 1, filtered.length
+    assert_equal 'input.hoge1', filtered[0][0] # tag
+    assert_equal 'record10', filtered[0][2]['field1']
+    assert_equal 10, filtered[0][2]['field2']
 
     d2 = create_driver(%[
       interval 3
     ], 'input.hoge2')
     time = Time.parse("2012-01-02 13:14:15").to_i
     d2.run do
-      d2.emit({'field1' => 'record1', 'field2' => 1})
-      d2.emit({'field1' => 'record2', 'field2' => 2})
-      d2.emit({'field1' => 'record3', 'field2' => 3})
-      d2.emit({'field1' => 'record4', 'field2' => 4})
-      d2.emit({'field1' => 'record5', 'field2' => 5})
-      d2.emit({'field1' => 'record6', 'field2' => 6})
-      d2.emit({'field1' => 'record7', 'field2' => 7})
-      d2.emit({'field1' => 'record8', 'field2' => 8})
-      d2.emit({'field1' => 'record9', 'field2' => 9})
-      d2.emit({'field1' => 'record10', 'field2' => 10})
-      d2.emit({'field1' => 'record11', 'field2' => 11})
-      d2.emit({'field1' => 'record12', 'field2' => 12})
+      d2.filter({'field1' => 'record1', 'field2' => 1})
+      d2.filter({'field1' => 'record2', 'field2' => 2})
+      d2.filter({'field1' => 'record3', 'field2' => 3})
+      d2.filter({'field1' => 'record4', 'field2' => 4})
+      d2.filter({'field1' => 'record5', 'field2' => 5})
+      d2.filter({'field1' => 'record6', 'field2' => 6})
+      d2.filter({'field1' => 'record7', 'field2' => 7})
+      d2.filter({'field1' => 'record8', 'field2' => 8})
+      d2.filter({'field1' => 'record9', 'field2' => 9})
+      d2.filter({'field1' => 'record10', 'field2' => 10})
+      d2.filter({'field1' => 'record11', 'field2' => 11})
+      d2.filter({'field1' => 'record12', 'field2' => 12})
     end
-    emits = d2.emits
-    assert_equal 4, emits.length
-    assert_equal 'input.hoge2', emits[0][0] # tag
+    filtered = d2.filtered_as_array
+    assert_equal 4, filtered.length
+    assert_equal 'input.hoge2', filtered[0][0] # tag
 
-    assert_equal 'record3', emits[0][2]['field1']
-    assert_equal 'record6', emits[1][2]['field1']
-    assert_equal 'record9', emits[2][2]['field1']
-    assert_equal 'record12', emits[3][2]['field1']
+    assert_equal 'record3', filtered[0][2]['field1']
+    assert_equal 'record6', filtered[1][2]['field1']
+    assert_equal 'record9', filtered[2][2]['field1']
+    assert_equal 'record12', filtered[3][2]['field1']
   end
 
   def test_filter_minimum_rate
@@ -94,17 +94,17 @@ minimum_rate_per_min 100
     time = Time.parse("2012-01-02 13:14:15").to_i
     d.run do
       (1..100).each do |t|
-        d.emit({'times' => t, 'data' => 'x'})
+        d.filter({'times' => t, 'data' => 'x'})
       end
       (101..130).each do |t|
-        d.emit({'times' => t, 'data' => 'y'})
+        d.filter({'times' => t, 'data' => 'y'})
       end
     end
-    emits = d.emits
-    assert_equal 103, emits.length
-    assert_equal 'input.hoge3', emits[0][0]
-    assert_equal ((1..100).map(&:to_i) + [110, 120, 130]), emits.map{|t,time,r| r['times']}
-    assert_equal (['x']*100 + ['y']*3), emits.map{|t,time,r| r['data']}
+    filtered = d.filtered_as_array
+    assert_equal 103, filtered.length
+    assert_equal 'input.hoge3', filtered[0][0]
+    assert_equal ((1..100).map(&:to_i) + [110, 120, 130]), filtered.map{|t,time,r| r['times']}
+    assert_equal (['x']*100 + ['y']*3), filtered.map{|t,time,r| r['data']}
 
   end
   def test_filter_minimum_rate_expire
@@ -121,18 +121,19 @@ minimum_rate_per_min 10
     time = Time.parse("2012-01-02 13:14:15").to_i
     d.run do
       (1..100).each do |t|
-        d.emit({'times' => t, 'data' => 'x'})
+        d.filter({'times' => t, 'data' => 'x'})
       end
-      sleep 60
+      sleep 10
+      # sleep 60
       (101..130).each do |t|
-        d.emit({'times' => t, 'data' => 'y'})
+        d.filter({'times' => t, 'data' => 'y'})
       end
     end
-    emits = d.emits
-    # assert_equal (19 + 12), emits.length
-    assert_equal 'input.hoge4', emits[0][0]
-    assert_equal ((1..10).map(&:to_i)+[20,30,40,50,60,70,80,90,100]+(101..110).map(&:to_i)+[120,130]), emits.map{|t,time,r| r['times']}
-    assert_equal (['x']*19 + ['y']*12), emits.map{|t,time,r| r['data']}
+    filtered = d.filtered_as_array
+    # assert_equal (19 + 12), filtered.length
+    assert_equal 'input.hoge4', filtered[0][0]
+    assert_equal ((1..10).map(&:to_i)+[20,30,40,50,60,70,80,90,100]+(101..110).map(&:to_i)+[120,130]), filtered.map{|t,time,r| r['times']}
+    assert_equal (['x']*19 + ['y']*12), filtered.map{|t,time,r| r['data']}
   end
 
   def test_filter_without_add_prefix_but_remove_prefix
@@ -143,11 +144,11 @@ interval 10
     time = Time.parse("2012-01-02 13:14:15").to_i
     d.run do
       (1..100).each do |t|
-        d.emit({'times' => t, 'data' => 'x'})
+        d.filter({'times' => t, 'data' => 'x'})
       end
     end
-    emits = d.emits
-    assert_equal 10, emits.length
-    assert_equal 'input.hoge3', emits[0][0]
+    filtered = d.filtered_as_array
+    assert_equal 10, filtered.length
+    assert_equal 'input.hoge3', filtered[0][0]
   end
 end

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -1,0 +1,153 @@
+require 'helper'
+
+class SamplingFilterTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[
+    interval 10
+    sample_unit tag
+  ]
+
+  def create_driver(conf=CONFIG,tag='test')
+    Fluent::Test::FilterTestDriver.new(Fluent::SamplingFilter, tag).configure(conf)
+  end
+
+  def test_configure
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver('')
+    }
+    d = create_driver %[
+      interval 5
+    ]
+
+    assert_equal 5, d.instance.interval
+    assert_equal :tag, d.instance.sample_unit
+
+    d = create_driver %[
+      interval 1000
+      sample_unit all
+    ]
+    assert_equal 1000, d.instance.interval
+    assert_equal :all, d.instance.sample_unit
+  end
+
+  def test_filter
+    d1 = create_driver(CONFIG, 'input.hoge1')
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d1.run do
+      d1.emit({'field1' => 'record1', 'field2' => 1})
+      d1.emit({'field1' => 'record2', 'field2' => 2})
+      d1.emit({'field1' => 'record3', 'field2' => 3})
+      d1.emit({'field1' => 'record4', 'field2' => 4})
+      d1.emit({'field1' => 'record5', 'field2' => 5})
+      d1.emit({'field1' => 'record6', 'field2' => 6})
+      d1.emit({'field1' => 'record7', 'field2' => 7})
+      d1.emit({'field1' => 'record8', 'field2' => 8})
+      d1.emit({'field1' => 'record9', 'field2' => 9})
+      d1.emit({'field1' => 'record10', 'field2' => 10})
+      d1.emit({'field1' => 'record11', 'field2' => 11})
+      d1.emit({'field1' => 'record12', 'field2' => 12})
+    end
+    emits = d1.emits
+    assert_equal 1, emits.length
+    assert_equal 'input.hoge1', emits[0][0] # tag
+    assert_equal 'record10', emits[0][2]['field1']
+    assert_equal 10, emits[0][2]['field2']
+
+    d2 = create_driver(%[
+      interval 3
+    ], 'input.hoge2')
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d2.run do
+      d2.emit({'field1' => 'record1', 'field2' => 1})
+      d2.emit({'field1' => 'record2', 'field2' => 2})
+      d2.emit({'field1' => 'record3', 'field2' => 3})
+      d2.emit({'field1' => 'record4', 'field2' => 4})
+      d2.emit({'field1' => 'record5', 'field2' => 5})
+      d2.emit({'field1' => 'record6', 'field2' => 6})
+      d2.emit({'field1' => 'record7', 'field2' => 7})
+      d2.emit({'field1' => 'record8', 'field2' => 8})
+      d2.emit({'field1' => 'record9', 'field2' => 9})
+      d2.emit({'field1' => 'record10', 'field2' => 10})
+      d2.emit({'field1' => 'record11', 'field2' => 11})
+      d2.emit({'field1' => 'record12', 'field2' => 12})
+    end
+    emits = d2.emits
+    assert_equal 4, emits.length
+    assert_equal 'input.hoge2', emits[0][0] # tag
+
+    assert_equal 'record3', emits[0][2]['field1']
+    assert_equal 'record6', emits[1][2]['field1']
+    assert_equal 'record9', emits[2][2]['field1']
+    assert_equal 'record12', emits[3][2]['field1']
+  end
+
+  def test_filter_minimum_rate
+    config = %[
+interval 10
+sample_unit tag
+minimum_rate_per_min 100
+]
+    d = create_driver(config, 'input.hoge3')
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d.run do
+      (1..100).each do |t|
+        d.emit({'times' => t, 'data' => 'x'})
+      end
+      (101..130).each do |t|
+        d.emit({'times' => t, 'data' => 'y'})
+      end
+    end
+    emits = d.emits
+    assert_equal 103, emits.length
+    assert_equal 'input.hoge3', emits[0][0]
+    assert_equal ((1..100).map(&:to_i) + [110, 120, 130]), emits.map{|t,time,r| r['times']}
+    assert_equal (['x']*100 + ['y']*3), emits.map{|t,time,r| r['data']}
+
+  end
+  def test_filter_minimum_rate_expire
+    # hey, this test needs 60 seconds....
+    assert_equal 1, 1
+    return
+
+    config = %[
+interval 10
+sample_unit tag
+minimum_rate_per_min 10
+]
+    d = create_driver(config, 'input.hoge4')
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d.run do
+      (1..100).each do |t|
+        d.emit({'times' => t, 'data' => 'x'})
+      end
+      sleep 60
+      (101..130).each do |t|
+        d.emit({'times' => t, 'data' => 'y'})
+      end
+    end
+    emits = d.emits
+    # assert_equal (19 + 12), emits.length
+    assert_equal 'input.hoge4', emits[0][0]
+    assert_equal ((1..10).map(&:to_i)+[20,30,40,50,60,70,80,90,100]+(101..110).map(&:to_i)+[120,130]), emits.map{|t,time,r| r['times']}
+    assert_equal (['x']*19 + ['y']*12), emits.map{|t,time,r| r['data']}
+  end
+
+  def test_filter_without_add_prefix_but_remove_prefix
+    config = %[
+interval 10
+]
+    d = create_driver(config, 'input.hoge3')
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d.run do
+      (1..100).each do |t|
+        d.emit({'times' => t, 'data' => 'x'})
+      end
+    end
+    emits = d.emits
+    assert_equal 10, emits.length
+    assert_equal 'input.hoge3', emits[0][0]
+  end
+end

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -105,12 +105,11 @@ minimum_rate_per_min 100
     assert_equal 'input.hoge3', filtered[0][0]
     assert_equal ((1..100).map(&:to_i) + [110, 120, 130]), filtered.map{|t,time,r| r['times']}
     assert_equal (['x']*100 + ['y']*3), filtered.map{|t,time,r| r['data']}
-
   end
+
   def test_filter_minimum_rate_expire
     # hey, this test needs 60 seconds....
-    assert_equal 1, 1
-    return
+    omit("this test needs 60 seconds....") unless ENV["EXECLONGTEST"]
 
     config = %[
 interval 10

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -123,8 +123,7 @@ minimum_rate_per_min 10
       (1..100).each do |t|
         d.filter({'times' => t, 'data' => 'x'})
       end
-      sleep 10
-      # sleep 60
+      sleep 60
       (101..130).each do |t|
         d.filter({'times' => t, 'data' => 'y'})
       end

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -135,20 +135,4 @@ minimum_rate_per_min 10
     assert_equal ((1..10).map(&:to_i)+[20,30,40,50,60,70,80,90,100]+(101..110).map(&:to_i)+[120,130]), filtered.map{|t,time,r| r['times']}
     assert_equal (['x']*19 + ['y']*12), filtered.map{|t,time,r| r['data']}
   end
-
-  def test_filter_without_add_prefix_but_remove_prefix
-    config = %[
-interval 10
-]
-    d = create_driver(config, 'input.hoge3')
-    time = Time.parse("2012-01-02 13:14:15").to_i
-    d.run do
-      (1..100).each do |t|
-        d.filter({'times' => t, 'data' => 'x'})
-      end
-    end
-    filtered = d.filtered_as_array
-    assert_equal 10, filtered.length
-    assert_equal 'input.hoge3', filtered[0][0]
-  end
 end

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -108,9 +108,6 @@ minimum_rate_per_min 100
   end
 
   def test_filter_minimum_rate_expire
-    # hey, this test needs 60 seconds....
-    omit("this test needs 60 seconds....") unless ENV["EXECLONGTEST"]
-
     config = %[
 interval 10
 sample_unit tag
@@ -119,18 +116,14 @@ minimum_rate_per_min 10
     d = create_driver(config, 'input.hoge4')
     time = Time.parse("2012-01-02 13:14:15").to_i
     d.run do
-      (1..100).each do |t|
+      (1..30).each do |t|
         d.filter({'times' => t, 'data' => 'x'})
-      end
-      sleep 60
-      (101..130).each do |t|
-        d.filter({'times' => t, 'data' => 'y'})
       end
     end
     filtered = d.filtered_as_array
-    # assert_equal (19 + 12), filtered.length
+    assert_equal 12, filtered.length
     assert_equal 'input.hoge4', filtered[0][0]
-    assert_equal ((1..10).map(&:to_i)+[20,30,40,50,60,70,80,90,100]+(101..110).map(&:to_i)+[120,130]), filtered.map{|t,time,r| r['times']}
-    assert_equal (['x']*19 + ['y']*12), filtered.map{|t,time,r| r['data']}
+    assert_equal ((1..10).map(&:to_i)+[20,30]), filtered.map{|t,time,r| r['times']}
+    assert_equal (['x']*12), filtered.map{|t,time,r| r['data']}
   end
 end

--- a/test/plugin/test_out_sampling_filter.rb
+++ b/test/plugin/test_out_sampling_filter.rb
@@ -118,8 +118,7 @@ minimum_rate_per_min 100
   end
   def test_minimum_rate_expire
     # hey, this test needs 60 seconds....
-    assert_equal 1, 1
-    return
+    omit("this test needs 60 seconds....") unless ENV["EXECLONGTEST"]
 
     config = %[
 interval 10


### PR DESCRIPTION
This filter version of plugins is simply converted from output version.

And I added `omit` into output test. Because `omit` has a functionality to display why this test case should be omitted like this:

```log
$ bundle exec rake test
/Users/hhatake/.rbenv/versions/2.2.3/bin/ruby -I"lib:lib:test" -I"/Users/hhatake/.rbenv/versions/2.2.3/lib/ruby/2.2.0" "/Users/hhatake/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/test_*.rb" 
Loaded suite /Users/hhatake/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/rake_test_loader
Started
...O
=================================================================================================================================================================================================
this test needs 60 seconds.... [test_minimum_rate_expire(SamplingFilterOutputTest)]
/Users/hhatake/Github/fluent-plugin-sampling-filter/test/plugin/test_out_sampling_filter.rb:121:in `test_minimum_rate_expire'
=================================================================================================================================================================================================
.....

Finished in 2.142979 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
9 tests, 48 assertions, 0 failures, 0 errors, 0 pendings, 1 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4.20 tests/s, 22.40 assertions/s
```

This PR depends on #6.