### PR TITLE
Use  Record Accessor helper to allow samping based on message fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a [Fluentd](http://fluentd.org) plugin to sample matching messages to analyse and report messages behavior and emit sampled messages with modified tag.
 
-* sampling rate per tags, or for all
+* sampling rate per tags, message field, or all
 
 ## Requirements
 
@@ -21,13 +21,13 @@ This filter passes a specified part of whole events to following filter/output p
       @type any_great_input
       @label @mydata
     </source>
-    
+
     <label @mydata>
       <filter **>
         @type sampling
         interval 10    # pass 1/10 events to following plugins
       </filter>
-      
+
       <match **>
         @type ...
       </match>
@@ -39,14 +39,14 @@ Sampling is done for all events, but we can do it per matched tags:
       @type any_great_input
       @label @mydata
     </source>
-    
+
     <label @mydata>
       <filter **>
         @type sampling
         interval 10
         sample_unit tag # 1/10 events for each tags
       </filter>
-      
+
       <match **>
         @type ...
       </match>
@@ -65,7 +65,7 @@ Pickup 1/10 messages about each tags(default: `sample_unit tag`), and add tag pr
       interval 10
       add_prefix sampled
     </match>
-    
+
     <match sampled.**>
       # output configurations where to send sampled messages
     </match>
@@ -79,7 +79,7 @@ Pickup 1/100 messages of all matched messages, and modify tags from `input.**` t
       remove_prefix input
       add_prefix output
     </match>
-    
+
     <match sampled.**>
       # output configurations where to send sampled messages
     </match>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This filter passes a specified part of whole events to following filter/output p
     <label @mydata>
       <filter **>
         @type sampling
+        sample_unit all
         interval 10    # pass 1/10 events to following plugins
       </filter>
 
@@ -52,7 +53,31 @@ Sampling is done for all events, but we can do it per matched tags:
       </match>
     </label>
 
+
+We can also sample based on a value in the message
+
+    <source>
+      @type any_great_input
+      @label @mydata
+    </source>
+
+    <label @mydata>
+      <filter **>
+        @type sampling
+        interval 10
+        # pass 1/10 events per user given events like: { user: { name: "Bob" }, ... }
+        sample_unit $.user.name
+      </filter>
+
+      <match **>
+        @type ...
+      </match>
+    </label>
+
 `minimum_rate_per_min` option(integer) configures this plugin to pass events with the specified rate even how small is the total number of whole events.
+
+`sample_unit` option(string) configures this plugin to sample data based on tag(default), 'all', or by field value
+using the [record accessor syntax](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor).
 
 ### SamplingFilterOutput
 

--- a/lib/fluent/plugin/filter_sampling.rb
+++ b/lib/fluent/plugin/filter_sampling.rb
@@ -60,7 +60,7 @@ class Fluent::Plugin::SamplingFilter < Fluent::Plugin::Filter
 
   def record_key(tag, record)
     case @sample_unit
-    when :all
+    when 'all'
       'all'
     when 'tag'
       tag

--- a/test/plugin/test_filter_sampling.rb
+++ b/test/plugin/test_filter_sampling.rb
@@ -164,4 +164,23 @@ minimum_rate_per_min 10
     assert_equal 'record12', filtered[7][1]['field1']
     assert_equal 2, filtered[7][1]['field3']
   end
+
+  def test_filter_all
+    config = %[
+      interval 10
+      sample_unit all
+    ]
+    d1 = create_driver(config)
+    time = Time.parse("2012-01-02 13:14:15").to_i
+    d1.run do
+      6.times do |i|
+        [0,1].each do |j|
+          d1.feed("input.hoge#{2*i+j}", time, {'field1' => "record#{2*i+j+1}"})
+        end
+      end
+    end
+    filtered = d1.filtered
+    assert_equal 1, filtered.length
+    assert_equal 'record10', filtered[0][1]['field1']
+  end
 end


### PR DESCRIPTION
Currently sampling is done via single bucket 'all' or via the tag. However, it would be helpful to use an arbitrary field in the message instead of having to modify the tag to include said field.  This code change leverages the [plugin-helper-record_accessor](https://docs.fluentd.org/plugin-helper-overview/api-plugin-helper-record_accessor) to do the heavy lifting of extracting the value from the message. 

I'm happy to make changes, add more detail to the README, tests ...

closes: https://github.com/tagomoris/fluent-plugin-sampling-filter/issues/12